### PR TITLE
Revert "Modification of supported browsers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ The polyright PaymentTerminal application allows payments on any polyright syste
   - Windows Mobile 10.0.586
   - Android 4.4
   - iOS 11 *(coming soon)*
-- Compatible browsers: 
-  - Internet Explorer 
-  - Microsoft Edge
-  - Mozilla Firefox
 
 ### Installation
 1. Install application from App Store


### PR DESCRIPTION
The browser is not a prerequisite for the Payment Terminal URI Scheme. That has no relation.
Reverts polyright/PaymentTerminal-URI-Scheme#1